### PR TITLE
Add NTLM AUTH support

### DIFF
--- a/lib/smtp-connection.js
+++ b/lib/smtp-connection.js
@@ -935,6 +935,8 @@ SMTPConnection.prototype._actionAUTH_NTLM_TYPE1 = function(str, callback) {
     return;
 
   var type3Message = ntlm.createType3Message(type2Message, {
+    domain: this._auth.domain || '',
+    workstation: this._auth.workstation || '',
     username: this._auth.user,
     password: this._auth.pass
   });

--- a/lib/smtp-connection.js
+++ b/lib/smtp-connection.js
@@ -10,6 +10,7 @@ var crypto = require('crypto');
 var DataStream = require('./data-stream');
 var PassThrough = require('stream').PassThrough;
 var shared = require('nodemailer-shared');
+var ntlm = require('httpntlm/ntlm');
 
 module.exports = SMTPConnection;
 
@@ -305,6 +306,15 @@ SMTPConnection.prototype.login = function (authData, callback) {
                 this._actionAUTH_CRAM_MD5(str, callback);
             }.bind(this);
             this._sendCommand('AUTH CRAM-MD5');
+            return;
+        case 'NTLM':
+            this._currentAction = function(str) {
+                this._actionAUTH_NTLM_TYPE1(str, callback);
+            }.bind(this);
+            this._sendCommand('AUTH NTLM ' + ntlm.createType1Message({
+              domain: this._auth.domain || '',
+              workstation: this._auth.workstation || ''
+            }))
             return;
     }
 
@@ -899,6 +909,41 @@ SMTPConnection.prototype._actionAUTH_LOGIN_USER = function (str, callback) {
 };
 
 /**
+ * Handle the response for AUTH NTLM, which should be a
+ * '334 <challenge string>'. See http://davenport.sourceforge.net/ntlm.html
+ * We already sent the Type1 message, the challenge is a Type2 message, we
+ * need to respond with a Type3 message.
+ *
+ * @param {String} str Message from the server
+ */
+SMTPConnection.prototype._actionAUTH_NTLM_TYPE1 = function(str, callback) {
+  var challengeMatch = str.match(/^334\s+(.+)$/);
+  var challengeString = '';
+
+  if (!challengeMatch) {
+      return callback(this._formatError('Invalid login sequence while waiting for server challenge string', 'EAUTH', str));
+  } else {
+      challengeString = challengeMatch[1];
+  }
+
+  if (!challengeString.match(/NTLM.*/)){
+    challengeString = 'NTLM ' + challengeString;
+  }
+
+  var type2Message = ntlm.parseType2Message(challengeString, callback)
+  if (!type2Message)
+    return;
+
+  var type3Message = ntlm.createType3Message(type2Message, this._auth);
+
+  this._currentAction = function (str) {
+      this._actionAUTH_NTLM_TYPE3(str, callback);
+  }.bind(this);
+
+  this._sendCommand(type3Message);
+}
+
+/**
  * Handle the response for AUTH CRAM-MD5 command. We are expecting
  * '334 <challenge string>'. Data to be sent as response needs to be
  * base64 decoded challenge string, MD5 hashed using the password as
@@ -949,6 +994,14 @@ SMTPConnection.prototype._actionAUTH_CRAM_MD5_PASS = function (str, callback) {
     this.authenticated = true;
     callback(null, true);
 };
+
+/**
+ * Handles the TYPE3 response for NTLM authentication, if there's no error,
+ * the user can be considered logged in. Start waiting for a message to send
+ *
+ * @param {String} str Message from the server
+ */
+SMTPConnection.prototype._actionAUTH_NTLM_TYPE3 = SMTPConnection.prototype._actionAUTH_CRAM_MD5_PASS
 
 /**
  * Handle the response for AUTH LOGIN command. We are expecting

--- a/lib/smtp-connection.js
+++ b/lib/smtp-connection.js
@@ -934,7 +934,10 @@ SMTPConnection.prototype._actionAUTH_NTLM_TYPE1 = function(str, callback) {
   if (!type2Message)
     return;
 
-  var type3Message = ntlm.createType3Message(type2Message, this._auth);
+  var type3Message = ntlm.createType3Message(type2Message, {
+    username: this._auth.user,
+    password: this._auth.pass
+  });
 
   this._currentAction = function (str) {
       this._actionAUTH_NTLM_TYPE3(str, callback);

--- a/lib/smtp-connection.js
+++ b/lib/smtp-connection.js
@@ -311,7 +311,7 @@ SMTPConnection.prototype.login = function (authData, callback) {
             this._currentAction = function(str) {
                 this._actionAUTH_NTLM_TYPE1(str, callback);
             }.bind(this);
-            this._sendCommand('AUTH NTLM ' + ntlm.createType1Message({
+            this._sendCommand('AUTH ' + ntlm.createType1Message({
               domain: this._auth.domain || '',
               workstation: this._auth.workstation || ''
             }))

--- a/lib/smtp-connection.js
+++ b/lib/smtp-connection.js
@@ -939,7 +939,8 @@ SMTPConnection.prototype._actionAUTH_NTLM_TYPE1 = function(str, callback) {
     workstation: this._auth.workstation || '',
     username: this._auth.user,
     password: this._auth.pass
-  });
+  })
+  type3Message = type3Message.substring(5); // remove the "NTLM " prefix
 
   this._currentAction = function (str) {
       this._actionAUTH_NTLM_TYPE3(str, callback);

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "xoauth2": "^1.1.0"
   },
   "dependencies": {
+    "httpntlm": "^1.5.3",
     "nodemailer-shared": "1.0.4"
   }
 }


### PR DESCRIPTION
Adds NTLM AUTH support that works at least with Exchange 2007 with the one account I've been given - I'm afraid I can't test much beyond that, as I don't control the Exchange server.

It uses the NTLM protocol implementation from [SamDecrock's node-http-ntlm](https://github.com/SamDecrock/node-http-ntlm) and could be a little cleaner if the protocol were extracted to a separate repository from its use for HTTP plus a few other small changes (https://github.com/SamDecrock/node-http-ntlm/issues/36).

NTLM authentication optionally includes the windows domain and workstation, which can be passed through in the `auth` options, e.g.:

```
auth: {
    domain: 'windows-domain',
    workstation: 'windows-workstation',
    user: 'user@somedomain.com',
    pass: 'pass'
}
```
