### PR TITLE
Add support for DSN

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,11 @@ Where
   * **envelope** is the envelope object to use
     * **envelope.from** is the sender address
     * **envelope.to** is the recipient address or an array of addresses
+    * **envelope.dsn** is the dsn options
+      * **envelope.dsn.ret** return either the full message 'FULL' or only headers 'HDRS'
+      * **envelope.dsn.envid** sender's 'envelope identifier' for tracking
+      * **envelope.dsn.notify** when to send a DSN. Multiple options are OK - array or comma delimited. NEVER must appear by itself. Available options: 'NEVER', 'SUCCESS', 'FAILURE', 'DELAY'
+      * **envelope.dsn.orcpt** original recipient
   * **message** is either a String, Buffer or a Stream. All newlines are converted to \r\n and all dots are escaped automatically, no need to convert anything before.
   * **callback** is the callback to run once the sending is finished or failed. Callback has the following arguments
     * **err** and error object if sending failed

--- a/lib/smtp-connection.js
+++ b/lib/smtp-connection.js
@@ -699,6 +699,14 @@ SMTPConnection.prototype._setEnvelope = function (envelope, callback) {
     this._envelope.rejected = [];
     this._envelope.accepted = [];
 
+    if (this._envelope.dsn) {
+        try {
+            this._envelope.dsn = this._setDsnEnvelope(this._envelope.dsn);
+        } catch (err) {
+            return callback(this._formatError('Invalid dsn ' + err, 'EENVELOPE'));
+        }
+    }
+
     this._currentAction = function (str) {
         this._actionMAIL(str, callback);
     }.bind(this);
@@ -708,8 +716,66 @@ SMTPConnection.prototype._setEnvelope = function (envelope, callback) {
     if (useSmtpUtf8 && this._supportedExtensions.indexOf('SMTPUTF8') >= 0) {
         args.push('SMTPUTF8');
     }
+    
+    // If the server supports DSN and the envelope includes an DSN prop
+    // then append DSN params to the MAIL FROM command
+    if (this._envelope.dsn && this._supportedExtensions.indexOf('DSN') >= 0) {
+        if (this._envelope.dsn.ret) {
+            args.push('RET=' + this._envelope.dsn.ret);
+        }
+        if (this._envelope.dsn.envid) {
+            args.push('ENVID=' + this._envelope.dsn.envid);
+        }
+    }
 
     this._sendCommand('MAIL FROM:<' + (this._envelope.from) + '>' + (args.length ? ' ' + args.join(' ') : ''));
+};
+
+SMTPConnection.prototype._setDsnEnvelope = function(params) {
+    var ret = params.ret ? params.ret.toString().toUpperCase() : null;
+    if (ret && ['FULL', 'HDRS'].indexOf(ret) < 0) {
+        throw 'ret: ' + JSON.stringify(ret);
+    }
+    var envid = params.envid ? params.envid.toString() : null;
+    var notify = params.notify ? params.notify : null;
+    if (notify) {
+        if (typeof notify === 'string') {
+            notify = notify.split(",");
+        }
+        notify = notify.map(function(n) {
+            return n.trim().toUpperCase();
+        });
+        var validNotify = ['NEVER', 'SUCCESS', 'FAILURE', 'DELAY'];
+        var invaliNotify = notify.filter(function(n) {
+            return validNotify.indexOf(n) === -1;
+        });
+        if (invaliNotify.length || (notify.length > 1 && notify.indexOf('NEVER') >= 0)) {
+            throw 'notify: ' + JSON.stringify(notify.join(','));
+        }
+        notify = notify.join(',');
+    }
+    var orcpt = params.orcpt ? params.orcpt.toString() : null;
+    return {
+        ret: ret,
+        envid: envid,
+        notify: notify,
+        orcpt: orcpt
+    };
+};
+
+SMTPConnection.prototype._getDsnRcptToArgs = function(params) {
+  var args = [];
+  // If the server supports DSN and the envelope includes an DSN prop
+  // then append DSN params to the RCPT TO command
+  if (this._envelope.dsn && this._supportedExtensions.indexOf('DSN') >= 0) {
+        if (this._envelope.dsn.notify) {
+            args.push('NOTIFY=' + this._envelope.dsn.notify);
+        }
+        if (this._envelope.dsn.envid) {
+            args.push('ORCPT=' + this._envelope.dsn.orcpt);
+        }
+    }
+    return (args.length ? ' ' + args.join(' ') : '');
 };
 
 SMTPConnection.prototype._createSendStream = function (callback) {
@@ -819,6 +885,11 @@ SMTPConnection.prototype._actionEHLO = function (str) {
     // Detect if the server supports SMTPUTF8
     if (/[ \-]SMTPUTF8\b/mi.test(str)) {
         this._supportedExtensions.push('SMTPUTF8');
+    }
+    
+    // Detect if the server supports DSN
+    if (/[ \-]DSN\b/mi.test(str)) {
+        this._supportedExtensions.push('DSN');
     }
 
     // Detect if the server supports PLAIN auth
@@ -1091,7 +1162,7 @@ SMTPConnection.prototype._actionMAIL = function (str, callback) {
         this._currentAction = function (str) {
             this._actionRCPT(str, callback);
         }.bind(this);
-        this._sendCommand('RCPT TO:<' + this._envelope.curRecipient + '>');
+        this._sendCommand('RCPT TO:<' + this._envelope.curRecipient + '>' + this._getDsnRcptToArgs());
     }
 };
 
@@ -1122,7 +1193,7 @@ SMTPConnection.prototype._actionRCPT = function (str, callback) {
         this._currentAction = function (str) {
             this._actionRCPT(str, callback);
         }.bind(this);
-        this._sendCommand('RCPT TO:<' + this._envelope.curRecipient + '>');
+        this._sendCommand('RCPT TO:<' + this._envelope.curRecipient + '>' + this._getDsnRcptToArgs());
     }
 };
 

--- a/lib/smtp-connection.js
+++ b/lib/smtp-connection.js
@@ -771,7 +771,7 @@ SMTPConnection.prototype._getDsnRcptToArgs = function() {
         if (this._envelope.dsn.notify) {
             args.push('NOTIFY=' + this._envelope.dsn.notify);
         }
-        if (this._envelope.dsn.envid) {
+        if (this._envelope.dsn.orcpt) {
             args.push('ORCPT=' + this._envelope.dsn.orcpt);
         }
     }

--- a/lib/smtp-connection.js
+++ b/lib/smtp-connection.js
@@ -703,7 +703,7 @@ SMTPConnection.prototype._setEnvelope = function (envelope, callback) {
         try {
             this._envelope.dsn = this._setDsnEnvelope(this._envelope.dsn);
         } catch (err) {
-            return callback(this._formatError('Invalid dsn ' + err, 'EENVELOPE'));
+            return callback(this._formatError('Invalid dsn ' + err.message, 'EENVELOPE'));
         }
     }
 

--- a/lib/smtp-connection.js
+++ b/lib/smtp-connection.js
@@ -716,7 +716,7 @@ SMTPConnection.prototype._setEnvelope = function (envelope, callback) {
     if (useSmtpUtf8 && this._supportedExtensions.indexOf('SMTPUTF8') >= 0) {
         args.push('SMTPUTF8');
     }
-    
+
     // If the server supports DSN and the envelope includes an DSN prop
     // then append DSN params to the MAIL FROM command
     if (this._envelope.dsn && this._supportedExtensions.indexOf('DSN') >= 0) {
@@ -734,13 +734,13 @@ SMTPConnection.prototype._setEnvelope = function (envelope, callback) {
 SMTPConnection.prototype._setDsnEnvelope = function(params) {
     var ret = params.ret ? params.ret.toString().toUpperCase() : null;
     if (ret && ['FULL', 'HDRS'].indexOf(ret) < 0) {
-        throw 'ret: ' + JSON.stringify(ret);
+        throw new Error('ret: ' + JSON.stringify(ret));
     }
     var envid = params.envid ? params.envid.toString() : null;
     var notify = params.notify ? params.notify : null;
     if (notify) {
         if (typeof notify === 'string') {
-            notify = notify.split(",");
+            notify = notify.split(',');
         }
         notify = notify.map(function(n) {
             return n.trim().toUpperCase();
@@ -750,7 +750,7 @@ SMTPConnection.prototype._setDsnEnvelope = function(params) {
             return validNotify.indexOf(n) === -1;
         });
         if (invaliNotify.length || (notify.length > 1 && notify.indexOf('NEVER') >= 0)) {
-            throw 'notify: ' + JSON.stringify(notify.join(','));
+            throw new Error('notify: ' + JSON.stringify(notify.join(',')));
         }
         notify = notify.join(',');
     }
@@ -763,11 +763,11 @@ SMTPConnection.prototype._setDsnEnvelope = function(params) {
     };
 };
 
-SMTPConnection.prototype._getDsnRcptToArgs = function(params) {
-  var args = [];
-  // If the server supports DSN and the envelope includes an DSN prop
-  // then append DSN params to the RCPT TO command
-  if (this._envelope.dsn && this._supportedExtensions.indexOf('DSN') >= 0) {
+SMTPConnection.prototype._getDsnRcptToArgs = function() {
+    var args = [];
+    // If the server supports DSN and the envelope includes an DSN prop
+    // then append DSN params to the RCPT TO command
+    if (this._envelope.dsn && this._supportedExtensions.indexOf('DSN') >= 0) {
         if (this._envelope.dsn.notify) {
             args.push('NOTIFY=' + this._envelope.dsn.notify);
         }
@@ -886,7 +886,7 @@ SMTPConnection.prototype._actionEHLO = function (str) {
     if (/[ \-]SMTPUTF8\b/mi.test(str)) {
         this._supportedExtensions.push('SMTPUTF8');
     }
-    
+
     // Detect if the server supports DSN
     if (/[ \-]DSN\b/mi.test(str)) {
         this._supportedExtensions.push('DSN');


### PR DESCRIPTION
Add support for DSN - Delivery Status Notifications 

Base on sendmail help:
```
214-2.0.0 MAIL From:<sender> [ RET={ FULL | HDRS} ] [ ENVID=<envid> ]
214-2.0.0 RCPT To:<recipient> [ NOTIFY={NEVER,SUCCESS,FAILURE,DELAY} ]
214-2.0.0                    [ ORCPT=<recipient> ]
214-2.0.0       SMTP Delivery Status Notifications.
214-2.0.0 Descriptions:
214-2.0.0       RET     Return either the full message or only headers.
214-2.0.0       ENVID   Sender's "envelope identifier" for tracking.
214-2.0.0       NOTIFY  When to send a DSN. Multiple options are OK, comma-
214-2.0.0               delimited. NEVER must appear by itself.
214-2.0.0       ORCPT   Original recipient.
214 2.0.0 End of HELP info
```
... and RFC: https://tools.ietf.org/html/rfc3461