### PR TITLE
Structured Bunyan output

### DIFF
--- a/lib/smtp-connection.js
+++ b/lib/smtp-connection.js
@@ -426,7 +426,7 @@ SMTPConnection.prototype.reset = function (callback) {
 SMTPConnection.prototype._onConnect = function () {
     clearTimeout(this._connectionTimeout);
 
-    this.logger.info({component: 'smtp-connection', sid: this.id, address: this._socket.remoteAddress, port: this._socket.remotePort}, '%s established', this.id, this.secure ? 'Secure connection' : 'Connection');
+    this.logger.info({component: 'smtp-connection', sid: this.id, address: this._socket.remoteAddress, port: this._socket.remotePort}, '%s established', this.secure ? 'Secure connection' : 'Connection');
 
     if (this._destroyed) {
         // Connection was established after we already had canceled it

--- a/lib/smtp-connection.js
+++ b/lib/smtp-connection.js
@@ -175,7 +175,7 @@ util.inherits(SMTPConnection, EventEmitter);
 SMTPConnection.prototype.connect = function (connectCallback) {
     if (typeof connectCallback === 'function') {
         this.once('connect', function () {
-            this.logger.debug('[%s] SMTP handshake finished', this.id);
+            this.logger.debug({component: 'smtp-connection', sid: this.id}, 'SMTP handshake finished');
             connectCallback();
         }.bind(this));
     }
@@ -270,7 +270,7 @@ SMTPConnection.prototype.close = function () {
         closeMethod = 'destroy';
     }
 
-    this.logger.debug('[%s] Closing connection to the server using "%s"', this.id, closeMethod);
+    this.logger.debug({component: 'smtp-connection', sid: this.id}, 'Closing connection to the server using "%s"', closeMethod);
 
     var socket = this._socket && this._socket.socket || this._socket;
 
@@ -426,7 +426,7 @@ SMTPConnection.prototype.reset = function (callback) {
 SMTPConnection.prototype._onConnect = function () {
     clearTimeout(this._connectionTimeout);
 
-    this.logger.info('[%s] %s established to %s:%s', this.id, this.secure ? 'Secure connection' : 'Connection', this._socket.remoteAddress, this._socket.remotePort);
+    this.logger.info({component: 'smtp-connection', sid: this.id, address: this._socket.remoteAddress, port: this._socket.remotePort}, '%s established', this.id, this.secure ? 'Secure connection' : 'Connection');
 
     if (this._destroyed) {
         // Connection was established after we already had canceled it
@@ -513,7 +513,7 @@ SMTPConnection.prototype._onError = function (err, type, data, command) {
 
     err = this._formatError(err, type, data, command);
 
-    this.logger.error('[%s] %s', this.id, err.message);
+    this.logger.error({component: 'smtp-connection', sid: this.id, err: err}, err.message);
 
     this.emit('error', err);
     this.close();
@@ -555,7 +555,7 @@ SMTPConnection.prototype._formatError = function (message, type, response, comma
  * @event
  */
 SMTPConnection.prototype._onClose = function () {
-    this.logger.info('[%s] Connection closed', this.id);
+    this.logger.info({component: 'smtp-connection', sid: this.id}, 'Connection closed');
 
     if ([this._actionGreeting, this.close].indexOf(this._responseActions[0]) < 0 && !this._destroyed) {
         return this._onError(new Error('Connection closed unexpectedly'), 'ECONNECTION', false, 'CONN');
@@ -656,7 +656,7 @@ SMTPConnection.prototype._processResponse = function () {
     }
 
     if (this.options.debug) {
-        this.logger.debug('[%s] S: %s', this.id, str.replace(/\r?\n$/, ''));
+        this.logger.debug({component: 'smtp-connection', sid: this.id}, 'S: %s', str.replace(/\r?\n$/, ''));
     }
 
     if (!str.trim()) { // skip unexpected empty lines
@@ -689,7 +689,7 @@ SMTPConnection.prototype._sendCommand = function (str) {
     }
 
     if (this.options.debug) {
-        this.logger.debug('[%s] C: %s', this.id, (str || '').toString().replace(/\r?\n$/, ''));
+        this.logger.debug({component: 'smtp-connection', sid: this.id}, 'C: %s', (str || '').toString().replace(/\r?\n$/, ''));
     }
 
     this._socket.write(new Buffer(str + '\r\n', 'utf-8'));
@@ -864,14 +864,14 @@ SMTPConnection.prototype._createSendStream = function (callback) {
         logStream.on('readable', function () {
             var chunk;
             while ((chunk = logStream.read())) {
-                this.logger.debug('[%s] C: %s', this.id, chunk.toString('binary').replace(/\r?\n$/, ''));
+                this.logger.debug({component: 'smtp-connection', sid: this.id}, 'C: %s', chunk.toString('binary').replace(/\r?\n$/, ''));
             }
         }.bind(this));
         dataStream.pipe(logStream);
     }
 
     dataStream.once('end', function () {
-        this.logger.info('[%s] C: <%s bytes encoded mime message (source size %s bytes)>', this.id, dataStream.outByteCount, dataStream.inByteCount);
+        this.logger.info({component: 'smtp-connection', sid: this.id, outByteCount: dataStream.outByteCount, inByteCount: dataStream.inByteCount}, 'C: <encoded mime message>');
     }.bind(this));
 
     return dataStream;
@@ -1027,7 +1027,7 @@ SMTPConnection.prototype._actionHELO = function (str) {
 SMTPConnection.prototype._actionSTARTTLS = function (str) {
     if (str.charAt(0) !== '2') {
         if (this.options.opportunisticTLS) {
-            this.logger.info('[%s] Failed STARTTLS upgrade, continuing unencrypted', this.id);
+            this.logger.info({component: 'smtp-connection', sid: this.id}, 'Failed STARTTLS upgrade, continuing unencrypted');
             return this.emit('connect');
         }
         this._onError(new Error('Error upgrading connection with STARTTLS'), 'ETLS', str, 'STARTTLS');
@@ -1040,7 +1040,7 @@ SMTPConnection.prototype._actionSTARTTLS = function (str) {
             return;
         }
 
-        this.logger.info('[%s] Connection upgraded with STARTTLS', this.id);
+        this.logger.info({component: 'smtp-connection', sid: this.id}, 'Connection upgraded with STARTTLS');
 
         if (secured) {
             // restart session
@@ -1162,7 +1162,7 @@ SMTPConnection.prototype._actionAUTH_CRAM_MD5_PASS = function (str, callback) {
         return callback(this._formatError('Invalid login sequence while waiting for "235"', 'EAUTH', str, 'AUTH CRAM-MD5'));
     }
 
-    this.logger.info('[%s] User %s authenticated', this.id, JSON.stringify(this._user));
+    this.logger.info({component: 'smtp-connection', sid: this.id, user: this._user}, 'User authenticated');
     this.authenticated = true;
     callback(null, true);
 };
@@ -1178,7 +1178,7 @@ SMTPConnection.prototype._actionAUTH_NTLM_TYPE3 = function (str, callback) {
         return callback(this._formatError('Invalid login sequence while waiting for "235"', 'EAUTH', str, 'AUTH NTLM'));
     }
 
-    this.logger.info('[%s] User %s authenticated', this.id, JSON.stringify(this._user));
+    this.logger.info({component: 'smtp-connection', sid: this.id, user: this._user}, 'User authenticated');
     this.authenticated = true;
     callback(null, true);
 };
@@ -1227,11 +1227,11 @@ SMTPConnection.prototype._actionAUTHComplete = function (str, isRetry, callback)
     }
 
     if (str.charAt(0) !== '2') {
-        this.logger.info('[%s] User %s failed to authenticate', this.id, JSON.stringify(this._user));
+        this.logger.info({component: 'smtp-connection', sid: this.id, user: this._user}, 'User failed to authenticate');
         return callback(this._formatError('Invalid login', 'EAUTH', str, 'AUTH ' + this._authMethod));
     }
 
-    this.logger.info('[%s] User %s authenticated', this.id, JSON.stringify(this._user));
+    this.logger.info({component: 'smtp-connection', sid: this.id, user: this._user}, 'User authenticated');
     this.authenticated = true;
     callback(null, true);
 };
@@ -1398,7 +1398,7 @@ SMTPConnection.prototype._handleXOauth2Token = function (isRetry, callback) {
     if (this._auth.xoauth2 && typeof this._auth.xoauth2 === 'object') {
         this._auth.xoauth2[isRetry ? 'generateToken' : 'getToken'](function (err, token) {
             if (err) {
-                this.logger.info('[%s] User %s failed to authenticate', this.id, JSON.stringify(this._user));
+                this.logger.info({component: 'smtp-connection', sid: this.id, user: this._user}, 'User failed to authenticate');
                 return callback(this._formatError(err, 'EAUTH', false, 'AUTH XOAUTH2'));
             }
             this._sendCommand('AUTH XOAUTH2 ' + token);


### PR DESCRIPTION
Hi,

I'd like to send output from smtp-connection to Elasticsearch. It is wonderful that smtp-connection currently uses Bunyan as standard logger, so I can send the JSON output directly. It is very unfortunate that its output is not structured yet.

The most important is `session.id` (in short: sid). Putting this in to separate field allows me to filter (grep-like) some session by its correlation id, ie:

``` sh
bunyan -c 'this.sid=="JpKSt7xMUYS8"' < smtp-connection.log
```

Also this is nice to filter some errors by theirs code or by component (ie. I could filter the messages from the library only).

Errors might be too verbose, but you can either filter them out by ie.:

``` sh
jq -c 'del(.err)' smtp-connection.log | bunyan
```

or you can use custom (null) serializer for `err` field for Bunyan.
